### PR TITLE
Feat/analytics bigquery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,24 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	// Spring Boot 버전을 명시적으로 관리
+	set('springBootVersion', "3.4.4")
+	// Spring Boot 버전에 맞춰서 Spring Cloud 사용
+	set('springCloudVersion', "2024.0.0")
+	// Spring Cloud 버전에 맞춰서 Spring Cloud GCP 사용
+	set('springCloudGcpVersion', "6.1.1")
+}
+
+dependencyManagement {
+	imports {
+		// Spring Cloud GCP BOM
+		mavenBom "com.google.cloud:spring-cloud-gcp-dependencies:${springCloudGcpVersion}"
+		// Spring Cloud BOM
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -116,6 +134,12 @@ dependencies {
 	implementation 'software.amazon.awssdk:eventbridge:2.20.0' // 최신 버전 확인
 	implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
 
+
+	// BigQuery 연동을 위한 의존성 => BigQuery 클라이언트 API 사용 시 필요
+	implementation 'com.google.cloud:google-cloud-bigquery'
+
+	// Spring Cloud GCP BigQuery Starter
+	implementation 'com.google.cloud:spring-cloud-gcp-starter-bigquery'
 
 }
 

--- a/src/main/java/com/example/auctionmarket/common/redis/RedissonConfig.java
+++ b/src/main/java/com/example/auctionmarket/common/redis/RedissonConfig.java
@@ -13,8 +13,9 @@ public class RedissonConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://127.0.0.1:6379")
-                .setPassword("stockage");
+                .setAddress("redis://localhost:6379");
+                // .setAddress("redis://127.0.0.1:6379")
+                // .setPassword("stockage");
         return Redisson.create(config);
     }
 //

--- a/src/main/java/com/example/auctionmarket/common/redis/RedissonConfig.java
+++ b/src/main/java/com/example/auctionmarket/common/redis/RedissonConfig.java
@@ -13,9 +13,9 @@ public class RedissonConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://localhost:6379");
-                // .setAddress("redis://127.0.0.1:6379")
-                // .setPassword("stockage");
+                // .setAddress("redis://localhost:6379");
+                .setAddress("redis://127.0.0.1:6379")
+                .setPassword("stockage");
         return Redisson.create(config);
     }
 //

--- a/src/main/java/com/example/auctionmarket/domain/analytics/controller/BigQueryAnalyticsController.java
+++ b/src/main/java/com/example/auctionmarket/domain/analytics/controller/BigQueryAnalyticsController.java
@@ -1,0 +1,64 @@
+package com.example.auctionmarket.domain.analytics.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.auctionmarket.common.response.Response;
+import com.example.auctionmarket.domain.analytics.dto.request.DailyAverageBidRequest;
+import com.example.auctionmarket.domain.analytics.dto.request.HourlyAverageBidRequest;
+import com.example.auctionmarket.domain.analytics.dto.response.DailyAverageBidResponse;
+import com.example.auctionmarket.domain.analytics.dto.response.HourlyAverageBidResponse;
+import com.example.auctionmarket.domain.analytics.service.BigQueryAnalyticsService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/v1/analytics/bigquery")
+@RequiredArgsConstructor
+@Slf4j
+public class BigQueryAnalyticsController {
+
+	private final BigQueryAnalyticsService bigQueryAnalyticsService;
+
+	// 시간별 평균 낙찰가
+	@GetMapping("/hourly-average-bid")
+	public ResponseEntity<Response<List<HourlyAverageBidResponse>>> getHourlyAverageBid(
+		@Valid @ModelAttribute HourlyAverageBidRequest request
+	) {
+		// BigQuery 와 동기 방식으로 통신하기 때문에 InterruptedException 던질 가능성이 있음
+		try {
+			List<HourlyAverageBidResponse> responses = bigQueryAnalyticsService.getHourlyAverageBid(request);
+			return ResponseEntity.ok(Response.of(responses));
+
+		} catch (InterruptedException e) {
+
+			log.error("getHourlyAverageBid 에서 InterruptedException 발생", e);
+			Thread.currentThread().interrupt(); // 인터럽트 상태 복원
+			return ResponseEntity.internalServerError().body(Response.of(null));
+		}
+	}
+
+	// 일자별 평균 낙찰가
+	@GetMapping("/daily-average-bid")
+	public ResponseEntity<Response<List<DailyAverageBidResponse>>> getDailyAverageBidByCategory(
+		@Valid @ModelAttribute DailyAverageBidRequest request
+	) {
+		try {
+			List<DailyAverageBidResponse> responses = bigQueryAnalyticsService.getDailyAverageBidByCategory(request);
+			return ResponseEntity.ok(Response.of(responses));
+
+		} catch (InterruptedException e) {
+			log.error("getDailyAverageBidByCategory 에서 InterruptedException 발생", e);
+			Thread.currentThread().interrupt(); // 인터럽트 상태 복원
+			return ResponseEntity.internalServerError().body(Response.of(null));
+		}
+	}
+
+}

--- a/src/main/java/com/example/auctionmarket/domain/analytics/dto/request/DailyAverageBidRequest.java
+++ b/src/main/java/com/example/auctionmarket/domain/analytics/dto/request/DailyAverageBidRequest.java
@@ -1,0 +1,16 @@
+package com.example.auctionmarket.domain.analytics.dto.request;
+
+import com.example.auctionmarket.domain.product.enums.ProductCategory;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DailyAverageBidRequest {
+
+	@NotNull(message = "카테고리를 반드시 입력해주세요")
+	private ProductCategory category;
+
+}

--- a/src/main/java/com/example/auctionmarket/domain/analytics/dto/request/HourlyAverageBidRequest.java
+++ b/src/main/java/com/example/auctionmarket/domain/analytics/dto/request/HourlyAverageBidRequest.java
@@ -1,0 +1,19 @@
+package com.example.auctionmarket.domain.analytics.dto.request;
+
+import com.example.auctionmarket.domain.product.enums.ProductCategory;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HourlyAverageBidRequest {
+
+	@NotNull(message = "카테고리를 반드시 입력해주세요")
+	private ProductCategory category;
+
+	@Min(value = 1, message = "조회 기간은 최소 1일 이상이어야 합니다.")
+	private int days;
+}

--- a/src/main/java/com/example/auctionmarket/domain/analytics/dto/response/DailyAverageBidResponse.java
+++ b/src/main/java/com/example/auctionmarket/domain/analytics/dto/response/DailyAverageBidResponse.java
@@ -1,0 +1,16 @@
+package com.example.auctionmarket.domain.analytics.dto.response;
+
+import java.time.LocalDate;
+
+import com.example.auctionmarket.domain.product.enums.ProductCategory;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DailyAverageBidResponse {
+
+	private LocalDate auctionDate;
+	private double averageWinningBid;
+}

--- a/src/main/java/com/example/auctionmarket/domain/analytics/dto/response/HourlyAverageBidResponse.java
+++ b/src/main/java/com/example/auctionmarket/domain/analytics/dto/response/HourlyAverageBidResponse.java
@@ -1,0 +1,14 @@
+package com.example.auctionmarket.domain.analytics.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HourlyAverageBidResponse {
+
+	private int hourOfDay;
+
+	private double averageWinningBid;
+
+}

--- a/src/main/java/com/example/auctionmarket/domain/analytics/service/BigQueryAnalyticsService.java
+++ b/src/main/java/com/example/auctionmarket/domain/analytics/service/BigQueryAnalyticsService.java
@@ -1,0 +1,177 @@
+package com.example.auctionmarket.domain.analytics.service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.example.auctionmarket.domain.analytics.dto.request.DailyAverageBidRequest;
+import com.example.auctionmarket.domain.analytics.dto.request.HourlyAverageBidRequest;
+import com.example.auctionmarket.domain.analytics.dto.response.DailyAverageBidResponse;
+import com.example.auctionmarket.domain.analytics.dto.response.HourlyAverageBidResponse;
+import com.example.auctionmarket.domain.product.enums.ProductCategory;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.TableResult;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class BigQueryAnalyticsService {
+
+	private final BigQuery bigquery;
+
+	private final String projectId;
+	private final String datasetName;
+	private final String tableName;
+
+	// 프로퍼티 주입용 생성자
+	public BigQueryAnalyticsService(
+		BigQuery bigquery,
+		@Value("${gcp.bigquery.project-id}") String projectId,
+		@Value("${gcp.bigquery.dataset-name}") String datasetName,
+		@Value("${gcp.bigquery.table-name}") String tableName) {
+		this.bigquery = bigquery;
+		this.projectId = projectId;
+		this.datasetName = datasetName;
+		this.tableName = tableName;
+	}
+
+	// 시간별 평균 낙찰가
+	public List<HourlyAverageBidResponse> getHourlyAverageBid(HourlyAverageBidRequest request) throws InterruptedException {
+		String category = String.valueOf(request.getCategory());
+		int days = request.getDays();
+
+		// BigQuery SQL 쿼리 설정
+		String query = String.format(
+			"SELECT " +
+				"  EXTRACT(HOUR FROM auction_end_time) AS hour_of_day, " +
+				"  AVG(max_price) AS average_winning_bid " +
+				"FROM " +
+				"  `%s.%s.%s` " + // 테이블 경로 포맷팅
+				"WHERE " +
+				"  product_category = @category " + // 파라미터 @category
+				"  AND DATE(auction_end_time) >= DATE_SUB(CURRENT_DATE(), INTERVAL @days DAY) " + // 파라미터 @days
+				"  AND DATE(auction_end_time) <= CURRENT_DATE() " +
+				"GROUP BY " +
+				"  hour_of_day " +
+				"ORDER BY " +
+				"  hour_of_day;",
+			projectId, datasetName, tableName // 테이블 경로 삽입
+		);
+
+		log.info("getHourlyAverageBid: 파라미터: category = {}, days = {}", category, days);
+		log.info("getHourlyAverageBid: BigQuery 쿼리문 = {}", query);
+
+		// 쿼리 생성 + 파라미터 바인딩
+		QueryJobConfiguration queryConfig =
+			QueryJobConfiguration.newBuilder(query)
+				.addNamedParameter("category", QueryParameterValue.string(category))
+				.addNamedParameter("days", QueryParameterValue.int64(days))
+				.setUseLegacySql(false)
+				.build();
+
+		// 쿼리 실행 요청 => 고유한 Job UUID 생성 => UUID 충돌 방지
+		JobId jobId = JobId.of(UUID.randomUUID().toString());
+		Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
+
+		// 쿼리 완료 대기 => 동기
+		queryJob = queryJob.waitFor();
+
+		// 쿼리 실행 오류 확인
+		if (queryJob.getStatus().getError() != null) {
+			throw new RuntimeException("getHourlyAverageBid: BigQuery 작업 실패: " + queryJob.getStatus().getError().toString());
+		}
+
+		// 결과 가져오기
+		TableResult result = queryJob.getQueryResults();
+		List<HourlyAverageBidResponse> hourlyAverageBid = new ArrayList<>();
+
+		// 결과 처리
+		for (FieldValueList row : result.iterateAll()) {
+			int hourOfDay = (int) row.get("hour_of_day").getLongValue();
+			// average_winning_bid 널 처리
+			double averageWinningBid = row.get("average_winning_bid").isNull() ? 0.0 : row.get("average_winning_bid").getDoubleValue();
+			hourlyAverageBid.add(new HourlyAverageBidResponse(hourOfDay, averageWinningBid));
+		}
+
+		return hourlyAverageBid;
+	}
+
+	// 일자별 평균 낙찰가
+	public List<DailyAverageBidResponse> getDailyAverageBidByCategory(DailyAverageBidRequest request) throws InterruptedException {
+		String category = String.valueOf(request.getCategory());
+
+		// BigQuery SQL 쿼리 설정
+		String query = String.format(
+			"SELECT " +
+				"  DATE(auction_start_time) AS auction_date, " +
+				"  AVG(max_price) AS average_winning_bid " +
+				"FROM " +
+				"  `%s.%s.%s` " +
+				"WHERE " +
+				"  product_category = @category " +
+				"GROUP BY " +
+				"  auction_date " +
+				"ORDER BY " +
+				"  auction_date;",
+			projectId, datasetName, tableName
+		);
+
+		log.info("getDailyAverageBidByCategory: 파라미터: category = {}", category);
+		log.info("getDailyAverageBidByCategory: BigQuery 쿼리문 = {}", query);
+
+		// 쿼리 생성 + 파라미터 바인딩
+		QueryJobConfiguration queryConfig =
+			QueryJobConfiguration.newBuilder(query)
+				.addNamedParameter("category", QueryParameterValue.string(category))
+				.setUseLegacySql(false)
+				.build();
+
+		// 쿼리 실행 요청
+		JobId jobId = JobId.of(UUID.randomUUID().toString());
+		Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
+
+		// 쿼리 완료 대기
+		queryJob = queryJob.waitFor();
+
+		// 쿼리 실행 오류 확인
+		if (queryJob.getStatus().getError() != null) {
+			throw new RuntimeException("getDailyAverageBidByCategory: BigQuery 작업 실패: " + queryJob.getStatus().getError().toString());
+		}
+
+		// 결과 가져오기
+		TableResult result = queryJob.getQueryResults();
+		List<DailyAverageBidResponse> dailyAverageBid = new ArrayList<>();
+
+		// 결과 처리
+		for (FieldValueList row : result.iterateAll()) {
+			// BigQuery DATE 타입을 Java LocalDate 로 변환
+			String dateString = row.get("auction_date").getStringValue();
+			LocalDate auctionDate = LocalDate.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE);
+
+			// average_winning_bid 널 처리
+			double averageWinningBid = row.get("average_winning_bid").isNull() ?
+				0.0 : row.get("average_winning_bid").getDoubleValue();
+
+			dailyAverageBid.add(new DailyAverageBidResponse(auctionDate, averageWinningBid));
+		}
+
+		return dailyAverageBid;
+	}
+
+
+
+
+
+}

--- a/src/main/java/com/example/auctionmarket/domain/analytics/service/BigQueryAnalyticsService.java
+++ b/src/main/java/com/example/auctionmarket/domain/analytics/service/BigQueryAnalyticsService.java
@@ -108,7 +108,7 @@ public class BigQueryAnalyticsService {
 		return hourlyAverageBid;
 	}
 
-	// 일자별 평균 낙찰가
+	// 일자별 평균 낙찰가 (최근 1년)
 	public List<DailyAverageBidResponse> getDailyAverageBidByCategory(DailyAverageBidRequest request) throws InterruptedException {
 		String category = String.valueOf(request.getCategory());
 
@@ -121,6 +121,8 @@ public class BigQueryAnalyticsService {
 				"  `%s.%s.%s` " +
 				"WHERE " +
 				"  product_category = @category " +
+				"  AND DATE(auction_start_time) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR) " +
+				"  AND DATE(auction_start_time) <= CURRENT_DATE() " +
 				"GROUP BY " +
 				"  auction_date " +
 				"ORDER BY " +

--- a/src/main/java/com/example/auctionmarket/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/auctionmarket/global/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
 						new AntPathRequestMatcher("/v1/auth/**"),
 						new AntPathRequestMatcher("/v1/auctions/end"),
 						new AntPathRequestMatcher("/v2/auctions/**"),
+						new AntPathRequestMatcher("/v2/auctions/**"),
 						new AntPathRequestMatcher("/v3/auctions/**")).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,11 @@
 spring.application.name=AuctionMarket
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=${DB_URL}
+#spring.datasource.url=jdbc:mysql://localhost:3306/auction_market?serverTimezone=Asia/Seoul
 spring.datasource.username=${DB_USERNAME}
+#spring.datasource.username=root
 spring.datasource.password=${DB_PASSWORD}
+#spring.datasource.password=1234
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.show_sql=false
@@ -14,12 +17,13 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 
 jwt.secret.key=${JWT.SECRET.KEY}
+#jwt.secret.key=7JWI64WV7ZWY7IS47JqU6rCQ7IKs7ZW07JqU7J6Y7J6I7Ja07JqU
 WEBSOCKET.SERVER.URL=http://localhost:8081
 
 ##redis ??
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
-spring.cache.type=none
+#spring.cache.type=none
 
 ##elastic search
 spring.elasticsearch.uris = http://localhost:9200
@@ -41,3 +45,13 @@ cloud.aws.cloudfront.domain=${CLOUD_AWS_CLOUDFRONT_DOMAIN}
 #??? ??? ?? ?? ??
 spring.servlet.multipart.max-file-size=50MB
 spring.servlet.multipart.max-request-size=50MB
+
+# bigquery dataset
+spring.cloud.gcp.bigquery.dataset-name=${GCP_BIGQUERY_DATASET_NAME}
+
+# BigQuery Configuration
+gcp.bigquery.project-id=${GCP_BIGQUERY_PROJECT_ID}
+gcp.bigquery.dataset-name=${GCP_BIGQUERY_DATASET_NAME}
+gcp.bigquery.table-name=${GCP_BIGQUERY_TABLE_NAME}
+
+#logging.level.root=DEBUG


### PR DESCRIPTION
## 📌 What is this PR ?

클라이언트가 get 요청하면 빅쿼리와 연동하여 쿼리 결과를 json 형태로 응답하는 api 구현했습니다.

<br/>

## 🔎 Additions / Changes

## Additions
시간대별 평균 낙찰가 조회 쿼리: 특정 상품 카테고리에 대해, 사용자가 지정한 최근 일수(days) 동안 발생한 경매들의 종료 시각을 기준으로 시간대(0시~23시)별 평균 낙찰가(max_price의 평균)를 계산

일자별 평균 낙찰가 조회 쿼리: 특정 상품 카테고리에 대해, 최근 1년간 발생한 경매들의 시작일을 기준으로 일자별 평균 낙찰가(max_price의 평균)를 계산

## Changes
테스트를 위해 RedissonConfig 의 주소를 localhost:6379 으로 변경했다가 다시 롤백해 놨습니다.

<br/>

## 📷 Screenshot
해당 코드가 잘 실행되는 스크린샷을 남겨주세요

| 기능 | 스크린샷 |
| --- | --- |
| PNG | ![image](https://github.com/user-attachments/assets/9b3ec27c-f8c6-4e47-9b42-86de297d45d1) |

<br/>

## ✅ Test Checklist
- [ ] 추가, 수정된 코드 부분에서
- [ ] 그의 테스트 체크한 내용을 작성해 주세요
